### PR TITLE
Adjusted default config for MulRan

### DIFF
--- a/config/lidar_slam/run_mulran.yaml
+++ b/config/lidar_slam/run_mulran.yaml
@@ -2,7 +2,6 @@ setting:
   name: "test_mulran"
   output_root: "./experiments"
   pc_path: "./data/MulRan/kaist01"
-  pose_path: "./data/MulRan/kaist01/poses.txt" 
   deskew: True
 process:
   min_range_m: 3.0

--- a/config/lidar_slam/run_mulran.yaml
+++ b/config/lidar_slam/run_mulran.yaml
@@ -1,7 +1,7 @@
 setting:
   name: "test_mulran"
   output_root: "./experiments"
-  pc_path: "./data/MulRan/kaist01/Ouster"
+  pc_path: "./data/MulRan/kaist01"
   pose_path: "./data/MulRan/kaist01/poses.txt" 
   deskew: True
 process:


### PR DESCRIPTION
The default path for the given `kaist01` sequence should be shortened to exclude `/Ouster`, as the MulRan loader adds this explicitly and would result in it looking for pointclouds in `[...]/Ouster/Ouster` and for `global_poses.csv` in `[...]/Ouster`:

https://github.com/PRBonn/PIN_SLAM/blob/87b8a9c7651daa9830c6e66c7d012b55730e987c/dataset/dataloaders/mulran.py#L32-L39

`pose_path` was removed entirely, as it is unused.