### PR TITLE
fix: set DISPLAY environment variable only if unset

### DIFF
--- a/utils/tools.py
+++ b/utils/tools.py
@@ -59,7 +59,8 @@ def setup_experiment(config: Config, argv=None, debug_mode: bool = False):
         print("Using the pure CPU mode, this would be slow")
         
     # set X service (FIXME)
-    os.environ["DISPLAY"] = ":0"
+    if "DISPLAY" not in os.environ:
+        os.environ["DISPLAY"] = ":0"
 
     # set the random seed for all
     seed_anything(config.seed)


### PR DESCRIPTION
Upon investigation, I found that the environment variable `DISPLAY` was being statically set without checking if it was already defined.

Added a check to ensure that `DISPLAY` is only set to a default value if it is not already defined.