### PR TITLE
global2local lookup table small bug

### DIFF
--- a/model/neural_points.py
+++ b/model/neural_points.py
@@ -495,7 +495,8 @@ class NeuralPoints(nn.Module):
         self.local_mask = local_mask
 
         # if Flase (not in the local map), the mapping get an idx as -1
-        global2local = torch.full_like(local_mask, -1).long()
+        #global2local = torch.full_like(local_mask, -1).long()
+        global2local = torch.full_like(local_mask, -1, dtype=torch.long)
         
         local_indices = torch.nonzero(local_mask).flatten()
         local_point_count = local_indices.size(0)


### PR DESCRIPTION
Some small bug, where if local map is used, when querying, points inside global map (global index != -1) but outside local map will be mapped to index 1 of local map, instead of index -1.